### PR TITLE
Add events for beforeCheckpoint and afterRestore

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     api(libs.managed.crac)
     compileOnly(mn.micronaut.http.server.netty)
-    testRuntimeOnly(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.server.netty)
 }

--- a/crac/src/main/java/io/micronaut/crac/events/AfterRestoreEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/AfterRestoreEvent.java
@@ -27,6 +27,10 @@ import io.micronaut.crac.OrderedResource;
 @Experimental
 public class AfterRestoreEvent extends BaseTimedEvent {
 
+    /**
+     * @param resource The resource that triggered the event.
+     * @param timeTakenNanos The time token for the action to be processed in nanoseconds.
+     */
     public AfterRestoreEvent(OrderedResource resource, long timeTakenNanos) {
         super(resource, timeTakenNanos);
     }

--- a/crac/src/main/java/io/micronaut/crac/events/AfterRestoreEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/AfterRestoreEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.events;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.OrderedResource;
+
+/**
+ * An event fired after a CRaC checkpoint is restored.
+ *
+ * @author Tim Yates
+ * @since 1.0.0
+ */
+@Experimental
+public class AfterRestoreEvent extends BaseTimedEvent {
+
+    public AfterRestoreEvent(OrderedResource resource, long timeTakenNanos) {
+        super(resource, timeTakenNanos);
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
@@ -19,13 +19,13 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.crac.OrderedResource;
 
 import java.time.Instant;
+import java.util.EventObject;
 
 @Experimental
-abstract class BaseTimedEvent {
+abstract class BaseTimedEvent extends EventObject {
 
     private final Instant now;
     private final long timeTakenNanos;
-    private final OrderedResource resource;
 
     /**
      * A base class for CRaC events.
@@ -33,16 +33,9 @@ abstract class BaseTimedEvent {
      * @param timeTakenNanos The time token for the action to be processed in nanoseconds.
      */
     BaseTimedEvent(OrderedResource resource, long timeTakenNanos) {
-        this.resource = resource;
+        super(resource);
         this.now = Instant.now();
         this.timeTakenNanos = timeTakenNanos;
-    }
-
-    /**
-     * @return The resource that triggered the event.
-     */
-    public OrderedResource getResource() {
-        return resource;
     }
 
     /**

--- a/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.events;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.OrderedResource;
+
+import java.time.Instant;
+
+@Experimental
+abstract class BaseTimedEvent {
+
+    private final Instant now;
+    private final long timeTakenNanos;
+
+    BaseTimedEvent(OrderedResource resource, long timeTakenNanos) {
+        this.now = Instant.now();
+        this.timeTakenNanos = timeTakenNanos;
+    }
+
+    public Instant getNow() {
+        return now;
+    }
+
+    public long getTimeTakenNanos() {
+        return timeTakenNanos;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
@@ -27,20 +27,34 @@ abstract class BaseTimedEvent {
     private final long timeTakenNanos;
     private final OrderedResource resource;
 
+    /**
+     * A base class for CRaC events.
+     * @param resource The resource that triggered the event.
+     * @param timeTakenNanos The time token for the action to be processed in nanoseconds.
+     */
     BaseTimedEvent(OrderedResource resource, long timeTakenNanos) {
         this.resource = resource;
         this.now = Instant.now();
         this.timeTakenNanos = timeTakenNanos;
     }
 
+    /**
+     * @return The resource that triggered the event.
+     */
     public OrderedResource getResource() {
         return resource;
     }
 
+    /**
+     * @return The {@link Instant} the event was fired.
+     */
     public Instant getNow() {
         return now;
     }
 
+    /**
+     * @return The time token for the action to be processed in nanoseconds.
+     */
     public long getTimeTakenNanos() {
         return timeTakenNanos;
     }

--- a/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
@@ -21,6 +21,12 @@ import io.micronaut.crac.OrderedResource;
 import java.time.Instant;
 import java.util.EventObject;
 
+/**
+ * The base class for timed CRaC events.
+ *
+ * @author Tim Yates
+ * @since 1.0.0
+ */
 @Experimental
 abstract class BaseTimedEvent extends EventObject {
 

--- a/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BaseTimedEvent.java
@@ -25,10 +25,16 @@ abstract class BaseTimedEvent {
 
     private final Instant now;
     private final long timeTakenNanos;
+    private final OrderedResource resource;
 
     BaseTimedEvent(OrderedResource resource, long timeTakenNanos) {
+        this.resource = resource;
         this.now = Instant.now();
         this.timeTakenNanos = timeTakenNanos;
+    }
+
+    public OrderedResource getResource() {
+        return resource;
     }
 
     public Instant getNow() {

--- a/crac/src/main/java/io/micronaut/crac/events/BeforeCheckpointEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BeforeCheckpointEvent.java
@@ -27,6 +27,10 @@ import io.micronaut.crac.OrderedResource;
 @Experimental
 public class BeforeCheckpointEvent extends BaseTimedEvent {
 
+    /**
+     * @param resource The resource that triggered the event.
+     * @param timeTakenNanos The time token for the action to be processed in nanoseconds.
+     */
     public BeforeCheckpointEvent(OrderedResource resource, long timeTakenNanos) {
         super(resource, timeTakenNanos);
     }

--- a/crac/src/main/java/io/micronaut/crac/events/BeforeCheckpointEvent.java
+++ b/crac/src/main/java/io/micronaut/crac/events/BeforeCheckpointEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.events;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.OrderedResource;
+
+/**
+ * An event fired when a resource CRaC checkpoint occurs.
+ *
+ * @author Tim Yates
+ * @since 1.0.0
+ */
+@Experimental
+public class BeforeCheckpointEvent extends BaseTimedEvent {
+
+    public BeforeCheckpointEvent(OrderedResource resource, long timeTakenNanos) {
+        super(resource, timeTakenNanos);
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/events/package-info.java
+++ b/crac/src/main/java/io/micronaut/crac/events/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Events that are fired when the CRaC checkpoint methods are executed.
+ * @author Tim Yates
+ * @since 1.0.0
+ */
+package io.micronaut.crac.events;

--- a/crac/src/main/java/io/micronaut/crac/netty/NettyEmbeddedServerCracHander.java
+++ b/crac/src/main/java/io/micronaut/crac/netty/NettyEmbeddedServerCracHander.java
@@ -48,9 +48,13 @@ public class NettyEmbeddedServerCracHander implements OrderedResource {
     private final ApplicationEventPublisher<AfterRestoreEvent> afterRestoreEventPublisher;
     private final NettyEmbeddedServer server;
 
-    public NettyEmbeddedServerCracHander(ApplicationContext applicationContext, NettyEmbeddedServer server) {
-        beforeCheckpointEventPublisher = applicationContext.getEventPublisher(BeforeCheckpointEvent.class);
-        afterRestoreEventPublisher = applicationContext.getEventPublisher(AfterRestoreEvent.class);
+    public NettyEmbeddedServerCracHander(
+        ApplicationEventPublisher<BeforeCheckpointEvent> beforeCheckpointEventPublisher,
+        ApplicationEventPublisher<AfterRestoreEvent> afterRestoreEventPublisher,
+        NettyEmbeddedServer server
+    ) {
+        this.beforeCheckpointEventPublisher = beforeCheckpointEventPublisher;
+        this.afterRestoreEventPublisher = afterRestoreEventPublisher;
         this.server = server;
     }
 

--- a/crac/src/main/java/io/micronaut/crac/netty/NettyEmbeddedServerCracHander.java
+++ b/crac/src/main/java/io/micronaut/crac/netty/NettyEmbeddedServerCracHander.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.crac.netty;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.ApplicationEventPublisher;

--- a/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
@@ -1,0 +1,56 @@
+package io.micronaut.crac
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Context
+import io.micronaut.context.annotation.Requires
+import io.micronaut.crac.events.AfterRestoreEvent
+import io.micronaut.crac.events.BeforeCheckpointEvent
+import io.micronaut.crac.netty.NettyEmbeddedServerCracHander
+import io.micronaut.http.server.netty.NettyEmbeddedServer
+import io.micronaut.runtime.event.annotation.EventListener
+import spock.lang.Specification
+import jakarta.inject.Singleton
+
+class EventSpec extends Specification {
+
+    def "netty handler fires events"() {
+        given:
+        NettyEmbeddedServer server = ApplicationContext.run(NettyEmbeddedServer, ['spec.name': 'EventSpec'])
+        ApplicationContext ctx = server.getApplicationContext()
+        NettyEmbeddedServerCracHander handler = ctx.getBean(NettyEmbeddedServerCracHander)
+
+        when:
+        EventRecorder.clearEvents()
+        handler.beforeCheckpoint(null)
+        handler.afterRestore(null)
+
+        then:
+        EventRecorder.events == ["onCheckpoint", "onRestore"]
+
+        cleanup:
+        server.close()
+        ctx.close()
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "EventSpec")
+    @SuppressWarnings(['unused', 'GrMethodMayBeStatic'])
+    static class EventRecorder {
+
+        static List<String> events = []
+
+        @EventListener
+        void checkpointEvent(BeforeCheckpointEvent event) {
+            events << 'onCheckpoint'
+        }
+
+        @EventListener
+        void restoreEvent(AfterRestoreEvent event) {
+            events << 'onRestore'
+        }
+
+        static void clearEvents() {
+            events.clear()
+        }
+    }
+}

--- a/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.crac
 
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Context
 import io.micronaut.context.annotation.Requires
 import io.micronaut.crac.events.AfterRestoreEvent
 import io.micronaut.crac.events.BeforeCheckpointEvent

--- a/src/main/docs/guide/events.adoc
+++ b/src/main/docs/guide/events.adoc
@@ -1,0 +1,4 @@
+To notify external components when the default Resource handlers execute, there are two events; api:crac.events.BeforeCheckpointEvent[] and api:crac.events.AfterRestoreEvent[].
+These events contain the `java.time.Instant` that the action completed, the length of time it took to execute the action in nanoseconds, and the Resource that was acted upon.
+
+Please see the https://docs.micronaut.io/latest/guide/#contextEvents[Micronaut Framework guide] for information on how to listen for these events.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -3,6 +3,7 @@ introduction:
 releaseHistory: Release History
 installation: Installation
 resource: Resources
+events: Events
 context: Context Provider
 repository: Repository
 


### PR DESCRIPTION
These events store the time take in nanos to process the event, and the Instant the event occurred.

There was a request to be able to modify the existing NettyEmbeddedServerCracHander to provide timings (specifically to find out when the `afterRestore` handler was called).