### PR TITLE
Add a simulator for running CRaC specific code

### DIFF
--- a/crac/src/main/java/io/micronaut/crac/test/CheckpointSimulator.java
+++ b/crac/src/main/java/io/micronaut/crac/test/CheckpointSimulator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.test;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.core.annotation.Experimental;
+
+/**
+ * Provides a mechanism to simulate a checkpoint/restore for testing.
+ * @author Tim Yates
+ * @since 1.0.0
+ */
+@Experimental
+@DefaultImplementation(DefaultCheckpointSimulator.class)
+public interface CheckpointSimulator {
+
+    /**
+     * Simulates a checkpoint.
+     */
+    void runBeforeCheckpoint();
+
+    /**
+     * Simulates a restore.
+     */
+    void runAfterRestore();
+}

--- a/crac/src/main/java/io/micronaut/crac/test/DefaultCheckpointSimulator.java
+++ b/crac/src/main/java/io/micronaut/crac/test/DefaultCheckpointSimulator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.test;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.OrderedResource;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Provides a mechanism to simulate a checkpoint/restore for testing.
+ */
+@Singleton
+@Experimental
+@Requires(env = Environment.TEST)
+public class DefaultCheckpointSimulator implements CheckpointSimulator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultCheckpointSimulator.class);
+
+    private final List<OrderedResource> resources;
+
+    public DefaultCheckpointSimulator(List<OrderedResource> resources) {
+        this.resources = resources;
+    }
+
+    @Override
+    public void runBeforeCheckpoint() {
+        for (int i = resources.size() - 1; i >= 0; i--) {
+            OrderedResource resource = resources.get(i);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Running before checkpoint for resource: {} ({})", resource, resource.getOrder());
+            }
+            try {
+                resource.beforeCheckpoint(null);
+            } catch (Exception e) {
+                throw new SimulatorException(e);
+            }
+        }
+    }
+
+    @Override
+    public void runAfterRestore() {
+        resources.forEach(DefaultCheckpointSimulator::internalAfterRestore);
+    }
+
+    private static void internalAfterRestore(OrderedResource resource) {
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Running after restore for resource: {} ({})", resource, resource.getOrder());
+            }
+            resource.afterRestore(null);
+        } catch (Exception e) {
+            throw new SimulatorException(e);
+        }
+    }
+
+    static class SimulatorException extends RuntimeException {
+
+        public SimulatorException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/EventSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.crac.events.AfterRestoreEvent
 import io.micronaut.crac.events.BeforeCheckpointEvent
 import io.micronaut.crac.resources.NettyEmbeddedServerResource
+import io.micronaut.crac.test.CheckpointSimulator
 import io.micronaut.http.server.netty.NettyEmbeddedServer
 import io.micronaut.runtime.context.scope.refresh.RefreshEvent
 import io.micronaut.runtime.event.annotation.EventListener
@@ -20,16 +21,16 @@ class EventSpec extends Specification {
         given:
         NettyEmbeddedServer server = ApplicationContext.run(NettyEmbeddedServer, ['spec.name': 'EventSpec', 'crac.refresh-beans': config])
         ApplicationContext ctx = server.getApplicationContext()
-        List<OrderedResource> resources = ctx.getBeansOfType(OrderedResource)
+        CheckpointSimulator simulator = ctx.getBean(CheckpointSimulator)
 
         when:
         EventRecorder.clearEvents()
 
         and: "Checkpoints are notified created in reverse order as performed by the CRaC JDK"
-        resources.reverse()*.beforeCheckpoint(null)
+        simulator.runBeforeCheckpoint()
 
         and: "Restore handlers are notified in the order they were registered as performed by the CRaC JDK"
-        resources*.afterRestore(null)
+        simulator.runAfterRestore()
 
         then:
         EventRecorder.events == expected

--- a/crac/src/test/groovy/io/micronaut/crac/NettySpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/NettySpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.crac
 
 import io.micronaut.context.BeanContext
+import io.micronaut.crac.test.CheckpointSimulator
 import io.micronaut.http.server.netty.NettyEmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -15,10 +16,10 @@ class NettySpec extends Specification {
     void "checkpoint stops netty"() {
         given:
         NettyEmbeddedServer server = ctx.getBean(NettyEmbeddedServer)
-        List<OrderedResource> resources = ctx.getBeansOfType(OrderedResource)
+        CheckpointSimulator simulator = ctx.getBean(CheckpointSimulator)
 
         when: "we call the resources in the reverse order, as per how CRaC does it"
-        resources.reverse()*.beforeCheckpoint(null)
+        simulator.runBeforeCheckpoint()
 
         then:
         !server.running


### PR DESCRIPTION
Makes testing easier, and people don't need to remember which way round the triggers are executed.

Fixes #17