### PR TITLE
Add handler for HikariDataSource

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -10,5 +10,6 @@ dependencies {
     testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.groovy.sql)
+    testImplementation(mn.logback)
     testRuntimeOnly(mn.h2)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -5,5 +5,6 @@ plugins {
 dependencies {
     api(libs.managed.crac)
     compileOnly(mn.micronaut.http.server.netty)
+    compileOnly("io.micronaut.sql:micronaut-jdbc-hikari")
     testImplementation(mn.micronaut.http.server.netty)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     api(libs.managed.crac)
     compileOnly(mn.micronaut.http.server.netty)
-    compileOnly("io.micronaut.sql:micronaut-jdbc-hikari")
+    compileOnly(mn.micronaut.jdbc.hikari)
+
+    testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.http.server.netty)
+    testRuntimeOnly(mn.h2)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -9,5 +9,6 @@ dependencies {
 
     testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.groovy.sql)
     testRuntimeOnly(mn.h2)
 }

--- a/crac/src/main/java/io/micronaut/crac/CracConfiguration.java
+++ b/crac/src/main/java/io/micronaut/crac/CracConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.crac;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.Toggleable;
 
 import java.time.Duration;
@@ -32,5 +33,9 @@ public interface CracConfiguration extends Toggleable {
      */
     boolean isRefreshBeans();
 
+    /**
+     * @return The timeout to wait for a datasource to pause before taking a checkpoint.
+     */
+    @NonNull
     Duration getDatasourcePauseTimeout();
 }

--- a/crac/src/main/java/io/micronaut/crac/CracConfiguration.java
+++ b/crac/src/main/java/io/micronaut/crac/CracConfiguration.java
@@ -17,6 +17,8 @@ package io.micronaut.crac;
 
 import io.micronaut.core.util.Toggleable;
 
+import java.time.Duration;
+
 /**
  * Configuration for CRaC support. Enabled by default.
  *
@@ -29,4 +31,6 @@ public interface CracConfiguration extends Toggleable {
      * @return Whether to refresh beans prior to taking a checkpoint.
      */
     boolean isRefreshBeans();
+
+    Duration getDatasourcePauseTimeout();
 }

--- a/crac/src/main/java/io/micronaut/crac/CracConfigurationProperties.java
+++ b/crac/src/main/java/io/micronaut/crac/CracConfigurationProperties.java
@@ -17,6 +17,7 @@ package io.micronaut.crac;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.NonNull;
 
 import java.time.Duration;
 
@@ -82,6 +83,7 @@ public class CracConfigurationProperties implements CracConfiguration {
     }
 
     @Override
+    @NonNull
     public Duration getDatasourcePauseTimeout() {
         return datasourcePauseTimeout;
     }

--- a/crac/src/main/java/io/micronaut/crac/CracConfigurationProperties.java
+++ b/crac/src/main/java/io/micronaut/crac/CracConfigurationProperties.java
@@ -18,6 +18,8 @@ package io.micronaut.crac;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Experimental;
 
+import java.time.Duration;
+
 /**
  * Configuration for CRaC support. Enabled by default.
  *
@@ -39,9 +41,11 @@ public class CracConfigurationProperties implements CracConfiguration {
     @SuppressWarnings("WeakerAccess")
     public static final boolean DEFAULT_ENABLED = true;
     public static final boolean DEFAULT_REFRESH = true;
+    public static final String DEFAULT_DATASOURCE_PAUSE_TIMEOUT = "PT30S";
 
     private boolean enabled = DEFAULT_ENABLED;
     private boolean refreshBeans = DEFAULT_REFRESH;
+    private Duration datasourcePauseTimeout = Duration.parse(DEFAULT_DATASOURCE_PAUSE_TIMEOUT);
 
     /**
      * @return Whether CRaC is enabled.
@@ -75,5 +79,19 @@ public class CracConfigurationProperties implements CracConfiguration {
      */
     public void setRefreshBeans(boolean refreshBeans) {
         this.refreshBeans = refreshBeans;
+    }
+
+    @Override
+    public Duration getDatasourcePauseTimeout() {
+        return datasourcePauseTimeout;
+    }
+
+    /**
+     * The timeout to wait for a datasource to pause before taking a checkpoint. Default value ({@value #DEFAULT_DATASOURCE_PAUSE_TIMEOUT}).
+     *
+     * @param datasourcePauseTimeout The timeout to wait for a datasource to pause before taking a checkpoint.
+     */
+    public void setDatasourcePauseTimeout(Duration datasourcePauseTimeout) {
+        this.datasourcePauseTimeout = datasourcePauseTimeout;
     }
 }

--- a/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
@@ -19,6 +19,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracConfiguration;
 import io.micronaut.crac.CracEventPublisher;
 import io.micronaut.crac.CracResourceRegistrar;
 import io.micronaut.crac.OrderedResource;
@@ -49,16 +50,17 @@ public class DataSourceResource implements OrderedResource {
     private final Resource handler;
 
     public DataSourceResource(
+        CracConfiguration configuration,
         CracEventPublisher eventPublisher,
         DataSource dataSource
     ) {
         this.eventPublisher = eventPublisher;
-        this.handler = getHandler(dataSource);
+        this.handler = getHandler(dataSource, configuration);
     }
 
-    private Resource getHandler(DataSource dataSource) {
+    private Resource getHandler(DataSource dataSource, CracConfiguration configuration) {
         if (dataSource instanceof HikariDataSource) {
-            return new HikariDataSourceResource((HikariDataSource) dataSource);
+            return new HikariDataSourceResource((HikariDataSource) dataSource, configuration);
         } else {
             if (LOG.isWarnEnabled()) {
                 LOG.warn("DataSource {} is not currently supported by CRaC", dataSource.getClass().getName());

--- a/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
@@ -61,12 +61,11 @@ public class DataSourceResource implements OrderedResource {
     private Resource getHandler(DataSource dataSource, CracConfiguration configuration) {
         if (dataSource instanceof HikariDataSource) {
             return new HikariDataSourceResource((HikariDataSource) dataSource, configuration);
-        } else {
-            if (LOG.isWarnEnabled()) {
-                LOG.warn("DataSource {} is not currently supported by CRaC", dataSource.getClass().getName());
-            }
-            return new UnknownDataSourceResource(dataSource);
         }
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("DataSource {} is not currently supported by CRaC", dataSource.getClass().getName());
+        }
+        return new UnknownDataSourceResource(dataSource);
     }
 
     @Override

--- a/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/DataSourceResource.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracEventPublisher;
+import io.micronaut.crac.CracResourceRegistrar;
+import io.micronaut.crac.OrderedResource;
+import io.micronaut.crac.resources.datasources.HikariDataSourceResource;
+import io.micronaut.crac.resources.datasources.UnknownDataSourceResource;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+/**
+ * Register DataSources as CRaC resources on startup if CRaC is enabled.
+ *
+ * @author Tim Yates
+ * @since 1.1.0
+ */
+@Experimental
+@EachBean(DataSource.class)
+@Requires(classes = {DataSource.class})
+@Requires(bean = CracResourceRegistrar.class)
+public class DataSourceResource implements OrderedResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DataSourceResource.class);
+
+    private final CracEventPublisher eventPublisher;
+    private final Resource handler;
+
+    public DataSourceResource(
+        CracEventPublisher eventPublisher,
+        DataSource dataSource
+    ) {
+        this.eventPublisher = eventPublisher;
+        this.handler = getHandler(dataSource);
+    }
+
+    private Resource getHandler(DataSource dataSource) {
+        if (dataSource instanceof HikariDataSource) {
+            return new HikariDataSourceResource((HikariDataSource) dataSource);
+        } else {
+            if (LOG.isWarnEnabled()) {
+                LOG.warn("DataSource {} is not currently supported by CRaC", dataSource.getClass().getName());
+            }
+            return new UnknownDataSourceResource(dataSource);
+        }
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
+            long beforeStart = System.nanoTime();
+            try {
+                handler.beforeCheckpoint(context);
+            } catch (Exception e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("Error stopping datasource {}", handler, e);
+                }
+            }
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireAfterRestoreEvents(this, () -> {
+            long beforeStart = System.nanoTime();
+            try {
+                handler.afterRestore(context);
+            } catch (Exception e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("Error restoring datasource {}", handler, e);
+                }
+            }
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.datasources;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Handler for Hikari DataSources.
+ *
+ * @author Tim Yates
+ * @since 1.1.0
+ */
+public class HikariDataSourceResource implements Resource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HikariDataSourceResource.class);
+
+    private final HikariPoolMXBean poolBean;
+    private final HikariDataSource dataSource;
+
+    public HikariDataSourceResource(HikariDataSource dataSource) {
+        this.dataSource = dataSource;
+        if (!dataSource.isAllowPoolSuspension()) {
+            LOG.error("HikariDataSource {} is not configured to allow pool suspension. This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this", dataSource);
+        }
+        this.poolBean = dataSource.getHikariPoolMXBean();
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Suspending Hikari pool for {}", dataSource);
+        }
+        poolBean.suspendPool();
+        poolBean.softEvictConnections();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Waiting 30s for connections to be closed");
+        }
+        CompletableFuture<Void> awaitClosure = CompletableFuture.runAsync(this::waitForConnectionClosure);
+        awaitClosure.get(30, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Resuming hikari datasource {}", dataSource);
+        }
+        poolBean.resumePool();
+    }
+
+    private void waitForConnectionClosure() {
+        while (poolBean.getActiveConnections() > 0) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(100);
+            } catch (InterruptedException e) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("Interrupted while waiting for connections to be closed", e);
+                }
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
@@ -62,7 +62,7 @@ public class HikariDataSourceResource implements Resource {
         poolBean.softEvictConnections();
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Waiting 30s for connections to be closed");
+            LOG.debug("Waiting {} for connections to be closed", datasourcePauseTimeout);
         }
         CompletableFuture<Void> awaitClosure = CompletableFuture.runAsync(this::waitForConnectionClosure);
         awaitClosure.get(datasourcePauseTimeout.getSeconds(), TimeUnit.SECONDS);

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
@@ -17,11 +17,15 @@ package io.micronaut.crac.resources.datasources;
 
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracConfiguration;
 import org.crac.Context;
 import org.crac.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -31,18 +35,21 @@ import java.util.concurrent.TimeUnit;
  * @author Tim Yates
  * @since 1.1.0
  */
+@Experimental
 public class HikariDataSourceResource implements Resource {
 
     private static final Logger LOG = LoggerFactory.getLogger(HikariDataSourceResource.class);
 
     private final HikariPoolMXBean poolBean;
     private final HikariDataSource dataSource;
+    private final Duration datasourcePauseTimeout;
 
-    public HikariDataSourceResource(HikariDataSource dataSource) {
+    public HikariDataSourceResource(HikariDataSource dataSource, CracConfiguration configuration) {
         this.dataSource = dataSource;
         if (!dataSource.isAllowPoolSuspension()) {
-            LOG.error("{} is not configured to allow pool suspension. This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this", dataSource);
+            throw new ConfigurationException(dataSource + " is not configured to allow pool suspension. This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this");
         }
+        this.datasourcePauseTimeout = configuration.getDatasourcePauseTimeout();
         this.poolBean = dataSource.getHikariPoolMXBean();
     }
 
@@ -58,7 +65,7 @@ public class HikariDataSourceResource implements Resource {
             LOG.debug("Waiting 30s for connections to be closed");
         }
         CompletableFuture<Void> awaitClosure = CompletableFuture.runAsync(this::waitForConnectionClosure);
-        awaitClosure.get(30, TimeUnit.SECONDS);
+        awaitClosure.get(datasourcePauseTimeout.getSeconds(), TimeUnit.SECONDS);
     }
 
     @Override

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/HikariDataSourceResource.java
@@ -41,7 +41,7 @@ public class HikariDataSourceResource implements Resource {
     public HikariDataSourceResource(HikariDataSource dataSource) {
         this.dataSource = dataSource;
         if (!dataSource.isAllowPoolSuspension()) {
-            LOG.error("HikariDataSource {} is not configured to allow pool suspension. This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this", dataSource);
+            LOG.error("{} is not configured to allow pool suspension. This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this", dataSource);
         }
         this.poolBean = dataSource.getHikariPoolMXBean();
     }

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.datasources;
+
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+/**
+ * Handler for currently unhandled DataSources.
+ *
+ * @author Tim Yates
+ * @since 1.1.0
+ */
+public class UnknownDataSourceResource implements Resource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnknownDataSourceResource.class);
+
+    private final DataSource dataSource;
+
+    public UnknownDataSourceResource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        if (LOG.isErrorEnabled()) {
+            LOG.error("Cannot suspend DataSource {}", dataSource);
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        if (LOG.isErrorEnabled()) {
+            LOG.error("Cannot resume DataSource {}", dataSource);
+        }
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
@@ -43,14 +43,14 @@ public class UnknownDataSourceResource implements Resource {
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
         if (LOG.isWarnEnabled()) {
-            LOG.warn("Cannot suspend DataSource {}", dataSource);
+            LOG.warn("Cannot suspend DataSource {}", dataSource.getClass().getName());
         }
     }
 
     @Override
     public void afterRestore(Context<? extends Resource> context) throws Exception {
         if (LOG.isWarnEnabled()) {
-            LOG.warn("Cannot resume DataSource {}", dataSource);
+            LOG.warn("Cannot resume DataSource {}", dataSource.getClass().getName());
         }
     }
 }

--- a/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/datasources/UnknownDataSourceResource.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.crac.resources.datasources;
 
+import io.micronaut.core.annotation.Experimental;
 import org.crac.Context;
 import org.crac.Resource;
 import org.slf4j.Logger;
@@ -28,6 +29,7 @@ import javax.sql.DataSource;
  * @author Tim Yates
  * @since 1.1.0
  */
+@Experimental
 public class UnknownDataSourceResource implements Resource {
 
     private static final Logger LOG = LoggerFactory.getLogger(UnknownDataSourceResource.class);
@@ -40,15 +42,15 @@ public class UnknownDataSourceResource implements Resource {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        if (LOG.isErrorEnabled()) {
-            LOG.error("Cannot suspend DataSource {}", dataSource);
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Cannot suspend DataSource {}", dataSource);
         }
     }
 
     @Override
     public void afterRestore(Context<? extends Resource> context) throws Exception {
-        if (LOG.isErrorEnabled()) {
-            LOG.error("Cannot resume DataSource {}", dataSource);
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Cannot resume DataSource {}", dataSource);
         }
     }
 }

--- a/crac/src/test/groovy/io/micronaut/crac/ConfigurationSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/ConfigurationSpec.groovy
@@ -5,6 +5,9 @@ import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
 
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
 @MicronautTest
 class ConfigurationSpec extends Specification {
 
@@ -16,6 +19,7 @@ class ConfigurationSpec extends Specification {
         with(ctx.getBean(CracConfiguration)) {
             enabled
             refreshBeans
+            datasourcePauseTimeout == Duration.of(30, ChronoUnit.SECONDS)
         }
     }
 }

--- a/crac/src/test/groovy/io/micronaut/crac/CracConfigurationSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/CracConfigurationSpec.groovy
@@ -40,4 +40,17 @@ class CracConfigurationSpec extends Specification {
         cleanup:
         ctx.close()
     }
+
+    void "datasource pause timeout can be configured"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run('crac.datasource-pause-timeout': "PT1H")
+
+        expect:
+        with(ctx.getBean(CracConfiguration)) {
+            datasourcePauseTimeout.seconds == 3600
+        }
+
+        cleanup:
+        ctx.close()
+    }
 }

--- a/crac/src/test/groovy/io/micronaut/crac/HikariSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/HikariSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.crac
 
+import ch.qos.logback.classic.Logger
 import com.zaxxer.hikari.HikariDataSource
 import groovy.sql.Sql
 import io.micronaut.context.BeanContext
@@ -7,6 +8,8 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.crac.test.CheckpointSimulator
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import spock.lang.AutoCleanup
 import spock.lang.Specification
 
 import javax.sql.DataSource
@@ -17,12 +20,21 @@ import javax.sql.DataSource
 @Property(name = "datasources.default.password", value = "")
 @Property(name = "datasources.default.driver-class-name", value = "org.h2.Driver")
 @Property(name = "datasources.default.allow-pool-suspension", value = "true")
+@Property(name = "crac.datasource-pause-timeout", value = "PT3M")
 class HikariSpec extends Specification {
 
     @Inject
     BeanContext ctx
 
+    @AutoCleanup("stop")
+    MemoryAppender appender = new MemoryAppender()
+
     void "hikari is suspended and restarted"() {
+        given:
+        Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
+        l.addAppender(appender)
+        appender.start()
+
         when:
         DataSource dataSource = ctx.getBean(DataSource)
 
@@ -49,6 +61,9 @@ class HikariSpec extends Specification {
 
         then:
         !hikariDataSource.running
+
+        and:
+        appender.events.formattedMessage.any { it.contains("Waiting PT3M for connections to be closed") }
 
         when: "we trigger a restore"
         simulator.runAfterRestore()

--- a/crac/src/test/groovy/io/micronaut/crac/HikariSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/HikariSpec.groovy
@@ -1,0 +1,51 @@
+package io.micronaut.crac
+
+import com.zaxxer.hikari.HikariDataSource
+import io.micronaut.context.BeanContext
+import io.micronaut.context.annotation.Property
+import io.micronaut.crac.test.CheckpointSimulator
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+@MicronautTest
+@Property(name = "datasources.default.url", value = "jdbc:h2:mem:testdb")
+@Property(name = "datasources.default.username", value = "sa")
+@Property(name = "datasources.default.password", value = "")
+@Property(name = "datasources.default.driver-class-name", value = "org.h2.Driver")
+@Property(name = "datasources.default.allow-pool-suspension", value = "true")
+class HikariSpec extends Specification {
+
+    @Inject
+    BeanContext ctx
+
+    void "hikari is suspended and restarted"() {
+        when:
+        DataSource dataSource = ctx.getBean(DataSource)
+
+        then:
+        dataSource instanceof HikariDataSource
+
+        when:
+        HikariDataSource hikariDataSource = (HikariDataSource) dataSource
+
+        then: "Pool is configured as suspendable"
+        hikariDataSource.allowPoolSuspension
+        hikariDataSource.running
+
+        when:
+        CheckpointSimulator simulator = ctx.getBean(CheckpointSimulator)
+        simulator.runBeforeCheckpoint()
+
+        then:
+        !hikariDataSource.running
+
+        when:
+        simulator.runAfterRestore()
+
+        then:
+        hikariDataSource.running
+    }
+}

--- a/crac/src/test/groovy/io/micronaut/crac/HikariUnsuspendableSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/HikariUnsuspendableSpec.groovy
@@ -1,0 +1,81 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import com.zaxxer.hikari.HikariDataSource
+import groovy.sql.Sql
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.BeanContext
+import io.micronaut.crac.resources.DataSourceResource
+import io.micronaut.crac.test.CheckpointSimulator
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+class HikariUnsuspendableSpec extends Specification {
+
+    @Inject
+    BeanContext ctx
+
+    void "hikari is suspended and restarted"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.builder()
+                .properties(
+                        "datasources.default.url": "jdbc:h2:mem:testdb",
+                        "datasources.default.username": "sa",
+                        "datasources.default.password": "",
+                        "datasources.default.driver-class-name": "org.h2.Driver",
+                )
+                .build()
+        def appender = new MemoryAppender()
+        Logger l = (Logger) LoggerFactory.getLogger(DataSourceResource.packageName)
+        l.addAppender(appender)
+        appender.start()
+
+        when:
+        ctx.start()
+        DataSource dataSource = ctx.getBean(DataSource)
+
+        then:
+        dataSource instanceof HikariDataSource
+
+        when:
+        HikariDataSource hikariDataSource = (HikariDataSource) dataSource
+
+        then: "Pool is unsuspendable"
+        !hikariDataSource.allowPoolSuspension
+        hikariDataSource.running
+
+        when: "we make sure we've got a connection warmed up"
+        def rows = new Sql(dataSource).rows("select 1")
+
+        then:
+        rows.size() == 1
+        rows[0].values()[0] == 1
+
+        when: "we trigger a checkpoint"
+        CheckpointSimulator simulator = ctx.getBean(CheckpointSimulator)
+        simulator.runBeforeCheckpoint()
+
+        then: 'we get a useful error message'
+        appender.events.find {
+            it.message.contains('This will cause problems when the application is checkpointed. Please set configuration datasources.*.allow-pool-suspension to fix this') &&
+                    it.level == Level.ERROR
+        }
+
+        and: 'the failure is logged'
+        appender.events.find {
+            it.message.contains('Error stopping datasource') &&
+                    it.level == Level.ERROR
+        }
+
+        and: 'the pool is still running'
+        hikariDataSource.running
+
+        cleanup:
+        appender.stop()
+        ctx.close()
+    }
+}

--- a/crac/src/test/groovy/io/micronaut/crac/HikariUnsuspendableSpec.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/HikariUnsuspendableSpec.groovy
@@ -6,7 +6,6 @@ import com.zaxxer.hikari.HikariDataSource
 import groovy.sql.Sql
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanContext
-import io.micronaut.crac.resources.DataSourceResource
 import io.micronaut.crac.test.CheckpointSimulator
 import jakarta.inject.Inject
 import org.slf4j.LoggerFactory
@@ -30,7 +29,7 @@ class HikariUnsuspendableSpec extends Specification {
                 )
                 .build()
         def appender = new MemoryAppender()
-        Logger l = (Logger) LoggerFactory.getLogger(DataSourceResource.packageName)
+        Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
         l.addAppender(appender)
         appender.start()
 

--- a/crac/src/test/groovy/io/micronaut/crac/MemoryAppender.groovy
+++ b/crac/src/test/groovy/io/micronaut/crac/MemoryAppender.groovy
@@ -1,0 +1,20 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+class MemoryAppender extends AppenderBase<ILoggingEvent> {
+
+    private final List<ILoggingEvent> events = []
+
+    @Override
+    protected void append(ILoggingEvent e) {
+        synchronized (events) {
+            events.add(e)
+        }
+    }
+
+    List<ILoggingEvent> getEvents() {
+        events
+    }
+}


### PR DESCRIPTION
We have to generate a handler for each DataSource bean, but this currently only handles Hikari. Other DataSources will be done in separate PRs.

On shutdown, we first suspend the pool, then request the closure of all connections and wait 30s for them all to close.

When we restore, we simply resume the pool.

We cannot close the pool as this invalidates it, and it cannot be re-opened.

This also requires the configuration:

```
datasources.default.allow-pool-suspension: true
```

To allow pool suspension