### PR TITLE
Use the correct version of Logback to get the build working

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -5,13 +5,14 @@ plugins {
 dependencies {
     api(libs.managed.crac)
     compileOnly(mn.micronaut.http.server.netty)
-    compileOnly(mn.micronaut.jdbc.hikari)
-    compileOnly(mn.micronaut.data.tx)
+    compileOnly(mnSql.micronaut.jdbc.hikari)
+    compileOnly(libs.micronaut.data.tx)
 
-    testImplementation(mn.micronaut.data.tx)
-    testImplementation(mn.micronaut.jdbc.hikari)
+    testImplementation(libs.micronaut.data.tx)
+    testImplementation(mnSql.micronaut.jdbc.hikari)
+    testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.groovy.sql)
-    testImplementation(mn.logback)
-    testRuntimeOnly(mn.h2)
+    testImplementation(libs.logback)
+    testRuntimeOnly(libs.h2)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -8,6 +8,8 @@ dependencies {
     compileOnly(mn.micronaut.jdbc.hikari)
     compileOnly(mn.micronaut.data.tx)
 
+    testImplementation(platform(libs.micronaut.platform))
+
     testImplementation(mn.micronaut.data.tx)
     testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.http.server.netty)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -8,8 +8,6 @@ dependencies {
     compileOnly(mn.micronaut.jdbc.hikari)
     compileOnly(mn.micronaut.data.tx)
 
-    testImplementation(platform(libs.micronaut.platform))
-
     testImplementation(mn.micronaut.data.tx)
     testImplementation(mn.micronaut.jdbc.hikari)
     testImplementation(mn.micronaut.http.server.netty)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -6,9 +6,9 @@ dependencies {
     api(libs.managed.crac)
     compileOnly(mn.micronaut.http.server.netty)
     compileOnly(mnSql.micronaut.jdbc.hikari)
-    compileOnly(libs.micronaut.data.tx)
+    compileOnly(mnData.micronaut.data.tx)
 
-    testImplementation(libs.micronaut.data.tx)
+    testImplementation(mnData.micronaut.data.tx)
     testImplementation(mnSql.micronaut.jdbc.hikari)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.http.server.netty)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.groovy.sql)
     testImplementation(libs.logback)
-    testRuntimeOnly(libs.h2)
+    testRuntimeOnly(mnSql.h2)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -13,6 +13,6 @@ dependencies {
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.groovy.sql)
-    testImplementation(libs.logback)
+    testImplementation(mn.logback.classic)
     testRuntimeOnly(mnSql.h2)
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,11 +96,13 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="excludeScope" value="private"/>
+            <property name="accessModifiers" value="public, protected"/>
         </module>
         <module name="JavadocType"/>
         <module name="JavadocStyle"/>
-        <module name="MissingJavadocType"/>
+        <module name="MissingJavadocType">
+            <property name="severity" value="warning"/>
+        </module>
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->

--- a/crac/build.gradle.kts
+++ b/crac/build.gradle.kts
@@ -5,12 +5,3 @@ plugins {
 dependencies {
     testImplementation(mn.micronaut.serde.jackson)
 }
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "ch.qos.logback") {
-            useVersion("1.4.5")
-            because("Currently micronaut-bom is pulling in a version that requires 1.x slf4j, not 2.x")
-        }
-    }
-}

--- a/crac/build.gradle.kts
+++ b/crac/build.gradle.kts
@@ -1,16 +1,3 @@
 plugins {
     id("io.micronaut.build.internal.crac-module")
 }
-
-dependencies {
-    testImplementation(mn.micronaut.serde.jackson)
-}
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "ch.qos.logback") {
-            useVersion("1.4.5")
-            because("Currently micronaut-bom is pulling in a version that requires 1.x slf4j, not 2.x")
-        }
-    }
-}

--- a/crac/build.gradle.kts
+++ b/crac/build.gradle.kts
@@ -5,3 +5,12 @@ plugins {
 dependencies {
     testImplementation(mn.micronaut.serde.jackson)
 }
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "ch.qos.logback") {
+            useVersion("1.4.5")
+            because("Currently micronaut-bom is pulling in a version that requires 1.x slf4j, not 2.x")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ spock = "2.3-groovy-4.0"
 
 managed-crac = "0.1.3"
 
-h2 = "2.1.210"
+# Temporary until https://github.com/micronaut-projects/micronaut-core/pull/8388
 logback = "1.4.5"
 
 [libraries]
@@ -23,6 +23,6 @@ managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac
 #Should switch to importing the data catalog once we get a 4.0.0 based build
 micronaut-data-tx = { module = "io.micronaut.data:micronaut-data-tx", version.ref = "micronaut-data" }
 
+# Temporary until https://github.com/micronaut-projects/micronaut-core/pull/8388
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
-h2 = { module = "com.h2database:h2", version.ref = "h2" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,4 +7,6 @@ spock = "2.3-groovy-4.0"
 managed-crac = "0.1.3"
 
 [libraries]
+micronaut-platform = { module = "io.micronaut.bom:micronaut-bom", version.ref = "micronaut" }
+
 managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,4 @@ spock = "2.3-groovy-4.0"
 managed-crac = "0.1.3"
 
 [libraries]
-micronaut-platform = { module = "io.micronaut.bom:micronaut-bom", version.ref = "micronaut" }
-
 managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,16 +11,10 @@ spock = "2.3-groovy-4.0"
 
 managed-crac = "0.1.3"
 
-# Temporary until https://github.com/micronaut-projects/micronaut-core/pull/8388
-logback = "1.4.5"
-
 [libraries]
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serialization" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 
 managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac" }
-
-# Temporary until https://github.com/micronaut-projects/micronaut-core/pull/8388
-logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,11 +17,9 @@ logback = "1.4.5"
 [libraries]
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serialization" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
+micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 
 managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac" }
-
-#Should switch to importing the data catalog once we get a 4.0.0 based build
-micronaut-data-tx = { module = "io.micronaut.data:micronaut-data-tx", version.ref = "micronaut-data" }
 
 # Temporary until https://github.com/micronaut-projects/micronaut-core/pull/8388
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,28 @@
 [versions]
 micronaut = "4.0.0-SNAPSHOT"
+micronaut-data = "3.8.1"
 micronaut-docs = "2.0.0"
+micronaut-serialization = "2.0.0-SNAPSHOT"
+micronaut-sql = "5.0.0-SNAPSHOT"
 micronaut-test = "4.0.0-SNAPSHOT"
+
 groovy = "4.0.6"
 spock = "2.3-groovy-4.0"
+
 managed-crac = "0.1.3"
 
+h2 = "2.1.210"
+logback = "1.4.5"
+
 [libraries]
+micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serialization" }
+micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
+
 managed-crac = { module = "io.github.crac:org-crac", version.ref = "managed-crac" }
+
+#Should switch to importing the data catalog once we get a 4.0.0 based build
+micronaut-data-tx = { module = "io.micronaut.data:micronaut-data-tx", version.ref = "micronaut-data" }
+
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.0.2'
+    id 'io.micronaut.build.shared.settings' version '6.1.0'
 }
 
 // Required for 4.0.0-SNAPSHOT, can be removed after
@@ -24,4 +24,6 @@ include 'crac-bom'
 
 micronautBuild {
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-serde")
+    importMicronautCatalog("micronaut-sql")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.1.0'
+    id 'io.micronaut.build.shared.settings' version '6.1.1'
 }
 
 rootProject.name = 'crac-parent'

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,20 +9,14 @@ plugins {
     id 'io.micronaut.build.shared.settings' version '6.1.0'
 }
 
-// Required for 4.0.0-SNAPSHOT, can be removed after
-dependencyResolutionManagement {
-    repositories {
-        maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-        mavenCentral()
-    }
-}
-
 rootProject.name = 'crac-parent'
 
 include 'crac'
 include 'crac-bom'
 
 micronautBuild {
+    // Required for 4.0.0-SNAPSHOT, can be removed after
+    addSnapshotRepository()
     importMicronautCatalog()
     importMicronautCatalog("micronaut-data")
     importMicronautCatalog("micronaut-serde")

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         maven { url = "https://s01.oss.sonatype.org/content/repositories/snapshots" }
-        mavenLocal()
+        mavenCentral()
     }
 }
 
@@ -24,6 +24,7 @@ include 'crac-bom'
 
 micronautBuild {
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-data")
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-sql")
 }


### PR DESCRIPTION
Something is pulling in an old version of logback, which has bindings targeting slf4j-api versions 1.7.x or earlier.

Since we have moved to SLF4J 2.x, this causes an error.

I believe the cause is an old version of logback in the micronaut-bom, but until that is brought up to date, this is a temporary workaround