### PR TITLE
Redis support for CRaC

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-base.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id("io.micronaut.build.internal.module")
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(mn.micronaut.http.server.netty)
     compileOnly(mn.micronaut.jdbc.hikari)
     compileOnly(mn.micronaut.data.tx)
+    compileOnly(mn.micronaut.redis.lettuce)
 
     testImplementation(mn.micronaut.data.tx)
     testImplementation(mn.micronaut.jdbc.hikari)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.crac-module.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.micronaut.build.internal.module"
+    id("io.micronaut.build.internal.crac-base")
 }
 
 dependencies {

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.crac.OrderedResource;
+import org.crac.Context;
+import org.crac.Resource;
+
+/**
+ * Redis resources are removed from the context, so they are automatically recreated on restore.
+ *
+ * @author Tim Yates
+ * @since 1.2.1
+ */
+@Internal
+@Experimental
+public abstract class AbstractRedisResource implements OrderedResource {
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        // We destroy beans, so nothing occurs after restore
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/CracRedisConfiguration.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/CracRedisConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.micronaut.core.util.Toggleable;
+
+/**
+ * Configuration for Redis CRaC support. Enabled by default.
+ *
+ * @author Tim Yates
+ * @since 1.2.0
+ */
+public interface CracRedisConfiguration extends Toggleable {
+
+    /**
+     * @return Whether to destroy RedisCache beans prior to taking a checkpoint.
+     */
+    boolean isCacheEnabled();
+
+    /**
+     * @return Whether to destroy RedisCache beans prior to taking a checkpoint.
+     */
+    boolean isClientEnabled();
+
+    /**
+     * @return Whether to destroy StatefulRedisConnection beans prior to taking a checkpoint.
+     */
+    boolean isConnectionEnabled();
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/CracRedisConfigurationProperties.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/CracRedisConfigurationProperties.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracConfigurationProperties;
+
+/**
+ * Configuration for Redis CRaC support. Enabled by default.
+ *
+ * @author Tim Yates
+ * @since 1.2.0
+ */
+@Experimental
+@ConfigurationProperties(CracRedisConfigurationProperties.PREFIX)
+public class CracRedisConfigurationProperties implements CracRedisConfiguration {
+
+    public static final String PREFIX = CracConfigurationProperties.PREFIX + ".redis";
+
+    public static final boolean DEFAULT_ENABLED = true;
+    public static final boolean DEFAULT_CACHE_ENABLED = true;
+    public static final boolean DEFAULT_CLIENT_ENABLED = true;
+    public static final boolean DEFAULT_CONNECTION_ENABLED = true;
+
+    private boolean enabled = DEFAULT_ENABLED;
+    private boolean cacheEnabled = DEFAULT_CACHE_ENABLED;
+    private boolean clientEnabled = DEFAULT_CLIENT_ENABLED;
+    private boolean connectionEnabled = DEFAULT_CONNECTION_ENABLED;
+
+    /**
+     * @return Whether CRaC support for Redis is enabled.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Whether CRaC (Coordinated Restore at Checkpoint) support for Redis, even if we're on a supporting JDK, is enabled. Default value ({@value #DEFAULT_ENABLED}).
+     *
+     * @param enabled false if CRaC support for redis should be disabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public boolean isCacheEnabled() {
+        return cacheEnabled;
+    }
+
+    /**
+     * Whether to destroy RedisCache beans prior to taking a checkpoint. Default value ({@value #DEFAULT_CACHE_ENABLED}).
+     *
+     * @param cacheEnabled Whether to destroy RedisCache beans prior to taking a checkpoint.
+     */
+    public void setCacheEnabled(boolean cacheEnabled) {
+        this.cacheEnabled = cacheEnabled;
+    }
+
+    @Override
+    public boolean isClientEnabled() {
+        return clientEnabled;
+    }
+
+    /**
+     * Whether to destroy RedisClient beans prior to taking a checkpoint. Default value ({@value #DEFAULT_CLIENT_ENABLED}).
+     *
+     * @param clientEnabled Whether to destroy RedisClient beans prior to taking a checkpoint.
+     */
+    public void setClientEnabled(boolean clientEnabled) {
+        this.clientEnabled = clientEnabled;
+    }
+
+    @Override
+    public boolean isConnectionEnabled() {
+        return connectionEnabled;
+    }
+
+    /**
+     * Whether to destroy StatefulRedisConnection beans prior to taking a checkpoint. Default value ({@value #DEFAULT_CONNECTION_ENABLED}).
+     *
+     * @param connectionEnabled Whether to destroy StatefulRedisConnection beans prior to taking a checkpoint.
+     */
+    public void setConnectionEnabled(boolean connectionEnabled) {
+        this.connectionEnabled = connectionEnabled;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.micronaut.configuration.lettuce.cache.RedisCache;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracEventPublisher;
+import io.micronaut.crac.CracResourceRegistrar;
+import io.micronaut.crac.resources.NettyEmbeddedServerResource;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Destroys any RedisCache beans before checkpointing.
+ *
+ * @author Tim Yates
+ * @since 1.2.1
+ */
+@Experimental
+@EachBean(RedisCache.class)
+@Requires(classes = {RedisCache.class})
+@Requires(bean = CracResourceRegistrar.class)
+public class RedisCacheResource extends AbstractRedisResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisCacheResource.class);
+
+    private final BeanContext beanContext;
+    private final CracEventPublisher eventPublisher;
+    private final RedisCache redisCache;
+
+    public RedisCacheResource(
+        BeanContext beanContext,
+        CracEventPublisher eventPublisher,
+        RedisCache redisCache
+    ) {
+        this.beanContext = beanContext;
+        this.eventPublisher = eventPublisher;
+        this.redisCache = redisCache;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Destroying Redis cache {}", redisCache);
+            }
+            long beforeStart = System.nanoTime();
+            beanContext.destroyBean(redisCache);
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return NettyEmbeddedServerResource.ORDER - 2;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
@@ -20,9 +20,9 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.crac.CracEventPublisher;
 import io.micronaut.crac.CracResourceRegistrar;
-import io.micronaut.crac.resources.NettyEmbeddedServerResource;
 import org.crac.Context;
 import org.crac.Resource;
 import org.slf4j.Logger;
@@ -38,7 +38,10 @@ import org.slf4j.LoggerFactory;
 @EachBean(RedisCache.class)
 @Requires(classes = {RedisCache.class})
 @Requires(bean = CracResourceRegistrar.class)
+@Requires(property = RedisCacheResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
 public class RedisCacheResource extends AbstractRedisResource {
+
+    static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".cache-enabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisCacheResource.class);
 
@@ -66,10 +69,5 @@ public class RedisCacheResource extends AbstractRedisResource {
             beanContext.destroyBean(redisCache);
             return System.nanoTime() - beforeStart;
         });
-    }
-
-    @Override
-    public int getOrder() {
-        return NettyEmbeddedServerResource.ORDER - 2;
     }
 }

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.crac.CracEventPublisher;
 import io.micronaut.crac.CracResourceRegistrar;
 import io.micronaut.crac.resources.NettyEmbeddedServerResource;
@@ -38,7 +39,10 @@ import org.slf4j.LoggerFactory;
 @EachBean(RedisClient.class)
 @Requires(classes = {RedisClient.class})
 @Requires(bean = CracResourceRegistrar.class)
+@Requires(property = RedisClientResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
 public class RedisClientResource extends AbstractRedisResource {
+
+    static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".client-enabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisClientResource.class);
 

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.lettuce.core.RedisClient;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracEventPublisher;
+import io.micronaut.crac.CracResourceRegistrar;
+import io.micronaut.crac.resources.NettyEmbeddedServerResource;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Destroys any RedisClient beans before checkpointing.
+ *
+ * @author Tim Yates
+ * @since 1.2.1
+ */
+@Experimental
+@EachBean(RedisClient.class)
+@Requires(classes = {RedisClient.class})
+@Requires(bean = CracResourceRegistrar.class)
+public class RedisClientResource extends AbstractRedisResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisClientResource.class);
+
+    private final BeanContext beanContext;
+    private final CracEventPublisher eventPublisher;
+    private final RedisClient client;
+
+    public RedisClientResource(
+        BeanContext beanContext,
+        CracEventPublisher eventPublisher,
+        RedisClient client
+    ) {
+        this.beanContext = beanContext;
+        this.eventPublisher = eventPublisher;
+        this.client = client;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Destroying Redis client {}", client);
+            }
+            long beforeStart = System.nanoTime();
+            beanContext.destroyBean(client);
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return NettyEmbeddedServerResource.ORDER - 2;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.crac.CracEventPublisher;
 import io.micronaut.crac.CracResourceRegistrar;
 import io.micronaut.crac.resources.NettyEmbeddedServerResource;
@@ -38,7 +39,10 @@ import org.slf4j.LoggerFactory;
 @EachBean(StatefulRedisConnection.class)
 @Requires(classes = {StatefulRedisConnection.class})
 @Requires(bean = CracResourceRegistrar.class)
+@Requires(property = StatefulRedisConnectionResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
 public class StatefulRedisConnectionResource extends AbstractRedisResource {
+
+    static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".connection-enabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(StatefulRedisConnectionResource.class);
 

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.crac.CracEventPublisher;
+import io.micronaut.crac.CracResourceRegistrar;
+import io.micronaut.crac.resources.NettyEmbeddedServerResource;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Destroys any StatefulRedisConnection beans before checkpointing.
+ *
+ * @author Tim Yates
+ * @since 1.2.1
+ */
+@Experimental
+@EachBean(StatefulRedisConnection.class)
+@Requires(classes = {StatefulRedisConnection.class})
+@Requires(bean = CracResourceRegistrar.class)
+public class StatefulRedisConnectionResource extends AbstractRedisResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatefulRedisConnectionResource.class);
+
+    private final BeanContext beanContext;
+    private final CracEventPublisher eventPublisher;
+    private final StatefulRedisConnection<?, ?> connection;
+
+    public StatefulRedisConnectionResource(
+        BeanContext beanContext,
+        CracEventPublisher eventPublisher,
+        StatefulRedisConnection<?, ?> connection
+    ) {
+        this.beanContext = beanContext;
+        this.eventPublisher = eventPublisher;
+        this.connection = connection;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Destroying Redis stateful connection {}", connection);
+            }
+            long beforeStart = System.nanoTime();
+            beanContext.destroyBean(connection);
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return NettyEmbeddedServerResource.ORDER - 1;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/package-info.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * A set of classes to support Coordinated Restore at Checkpoint (CRaC) and Redis.
+ *
+ * @since 1.2.0
+ * @author Tim Yates
+ */
+@Configuration
+@Experimental
+@Requires(property = CracRedisConfigurationProperties.PREFIX + ".enabled", defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
+package io.micronaut.crac.resources.redis;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.util.StringUtils;

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ include 'test-suite-dbcp-jooq'
 include 'test-suite-groovy'
 include 'test-suite-hikari-jooq'
 include 'test-suite-kotlin'
+include 'test-suite-redis'
 
 micronautBuild {
     importMicronautCatalog()

--- a/src/main/docs/guide/resource.adoc
+++ b/src/main/docs/guide/resource.adoc
@@ -1,5 +1,0 @@
-To provide CRaC resources, create beans of type api:crac.OrderedResource[].
-
-Micronaut CRaC registers resources for you into the CRaC Context. You just focus on providing implementations for `OrderedResource::beforeCheckpoint` and `OrderedResource::afterRestore` in your resources.
-
-Micronaut CRaC registers resources in order. You can control the order by overriding `OrderedResource::getOrder`.

--- a/src/main/docs/guide/resource/custom.adoc
+++ b/src/main/docs/guide/resource/custom.adoc
@@ -1,0 +1,5 @@
+To provide custom CRaC resources, create beans of type api:crac.OrderedResource[].
+
+Micronaut CRaC registers resources for you into the CRaC Context. You just focus on providing implementations for `OrderedResource::beforeCheckpoint` and `OrderedResource::afterRestore` in your resources.
+
+Micronaut CRaC registers resources in order. You can control the order by overriding `OrderedResource::getOrder`.

--- a/src/main/docs/guide/resource/datasource.adoc
+++ b/src/main/docs/guide/resource/datasource.adoc
@@ -1,0 +1,10 @@
+We currently support https://micronaut-projects.github.io/micronaut-sql/latest/guide[Hikari DataSources] that are configured to allow suspension with:
+
+[configuration]
+----
+datasources:
+  default:
+    allow-pool-suspension: true
+----
+
+When a checkpoint is taken, the pool is suspended and the connections are closed.  When the checkpoint is restored, the pool is resumed and the connections are re-established.

--- a/src/main/docs/guide/resource/redis.adoc
+++ b/src/main/docs/guide/resource/redis.adoc
@@ -1,0 +1,17 @@
+Since v1.2.1 of this library, we also support Redis connections.
+
+When the checkpoint is taken, we destroy RedisClient, RedisCache and StatefulRedisConnection beans that exist in the application.
+
+These will be re-created once the checkpoint is restored, however you will need to add your beans to <<refresh,the refresh scope>> so that these new beans are used.
+
+The resources for each of the above can be disabled via configuration:
+
+[configuration]
+----
+crac:
+    redis:
+        enabled: false            # disable all redis support
+        client-enabled: false     # disable RedisClient support
+        cache-enabled: false      # disable RedisCache support
+        connection-enabled: false # disable StatefulRedisConnection support
+----

--- a/src/main/docs/guide/resource/redis.adoc
+++ b/src/main/docs/guide/resource/redis.adoc
@@ -1,6 +1,6 @@
 Since v1.2.1 of this library, we also support Redis connections.
 
-When the checkpoint is taken, we destroy RedisClient, RedisCache and StatefulRedisConnection beans that exist in the application.
+When the checkpoint is taken, we destroy `RedisClient`, `RedisCache` and `StatefulRedisConnection` beans that exist in the application.
 
 These will be re-created once the checkpoint is restored, however you will need to add your beans to <<refresh,the refresh scope>> so that these new beans are used.
 

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -2,7 +2,11 @@ introduction:
   title: Introduction
 releaseHistory: Release History
 installation: Installation
-resource: Resources
+resource:
+  title: CRaC Resources
+  datasource: DataSources
+  redis: Redis
+  custom: Custom CRaC Resources
 refresh: Refresh scope
 events: Events
 context: Context Provider

--- a/test-suite-redis/build.gradle.kts
+++ b/test-suite-redis/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     testImplementation(mn.micronaut.test.spock)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.cache.core)
     testImplementation(mn.micronaut.redis.lettuce)
     testImplementation(mn.logback)
 

--- a/test-suite-redis/build.gradle.kts
+++ b/test-suite-redis/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
     id("io.micronaut.test-resources") version "3.7.3"
 }
 
-repositories {
-    mavenCentral()
-    mavenLocal()
-}
-
 dependencies {
     testImplementation(project(":crac"))
     testImplementation(mn.micronaut.test.spock)

--- a/test-suite-redis/build.gradle.kts
+++ b/test-suite-redis/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("groovy")
+    id("io.micronaut.library") version "3.7.3"
+    id("io.micronaut.test-resources") version "3.7.3"
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    testImplementation(project(":crac"))
+    testImplementation(mn.micronaut.test.spock)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.inject.groovy)
+    testImplementation(mn.micronaut.redis.lettuce)
+    testImplementation(mn.logback)
+
+    testRuntimeOnly(mn.h2)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+micronaut {
+    version.set(libs.versions.micronaut.asProvider())
+    testResources {
+        additionalModules.set(listOf("redis"))
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/BaseCacheSpecification.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/BaseCacheSpecification.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.crac
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.crac.test.CheckpointSimulator
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+@MicronautTest
+class BaseCacheSpecification extends Specification {
+
+    @Inject
+    ApplicationContext ctx
+
+    @Inject
+    CheckpointSimulator simulator
+
+    @AutoCleanup("stop")
+    MemoryAppender appender = new MemoryAppender()
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/CacheSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/CacheSpec.groovy
@@ -1,0 +1,66 @@
+package io.micronaut.crac
+
+import io.micronaut.cache.annotation.Cacheable
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.PendingFeature
+
+@Property(name = "spec.name", value = "CacheSpec")
+@Property(name = "redis.caches.test.enabled", value = StringUtils.TRUE)
+class CacheSpec extends BaseCacheSpecification {
+
+    @Inject
+    @Client("/")
+    HttpClient client
+
+    @PendingFeature(reason = "Currently this doesn't work, as the CacheManager keeps hold of it's cache connections")
+    def "cache annotations work"() {
+        when:
+        def response = client.toBlocking().retrieve("/foo")
+
+        then:
+        response.startsWith('foo')
+
+        and:
+        client.toBlocking().retrieve("/foo") == response
+
+        when:
+        simulator.runBeforeCheckpoint()
+
+        and:
+        simulator.runAfterRestore()
+
+        then:
+        client.toBlocking().retrieve("/foo") == response
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "CacheSpec")
+    static class CacheService {
+
+        @Cacheable("test")
+        String get(String key) {
+            "$key:${UUID.randomUUID().toString()}"
+        }
+    }
+
+    @Controller
+    @Requires(property = "spec.name", value = "CacheSpec")
+    static class TestController {
+
+        @Inject
+        CacheService cacheService
+
+        @Get("/{key}")
+        String get(String key) {
+            cacheService.get(key)
+        }
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/CracRedisConfigurationSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/CracRedisConfigurationSpec.groovy
@@ -1,0 +1,105 @@
+package io.micronaut.crac
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.StringUtils
+import io.micronaut.crac.resources.redis.CracRedisConfiguration
+import io.micronaut.crac.resources.redis.RedisCacheResource
+import io.micronaut.crac.resources.redis.RedisClientResource
+import io.micronaut.crac.resources.redis.StatefulRedisConnectionResource
+import spock.lang.Specification
+
+class CracRedisConfigurationSpec extends Specification {
+
+    void "Redis CRaC enabled by default"() {
+        given:
+        def ctx = ApplicationContext.run(
+                "redis.enabled": StringUtils.TRUE,
+                "redis.caches.test.enabled": StringUtils.TRUE,
+        )
+
+        when:
+        def cfg = ctx.getBean(CracConfiguration)
+
+        then:
+        cfg.enabled
+
+        when:
+        def redisCfg = ctx.getBean(CracRedisConfiguration)
+
+        then:
+        redisCfg.enabled
+        redisCfg.cacheEnabled
+        redisCfg.clientEnabled
+        redisCfg.connectionEnabled
+
+        and:
+        ctx.containsBean(CracRedisConfiguration)
+        ctx.containsBean(RedisCacheResource)
+        ctx.containsBean(RedisClientResource)
+        ctx.containsBean(StatefulRedisConnectionResource)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "CRaC can be disabled and that disables Redis also"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run(
+                'redis.enabled': StringUtils.TRUE,
+                "redis.caches.test.enabled": StringUtils.TRUE,
+                'crac.enabled': StringUtils.FALSE
+        )
+
+        expect:
+        !ctx.containsBean(CracConfiguration)
+        !ctx.containsBean(CracContextProvider)
+        !ctx.containsBean(OrderedResource)
+        !ctx.containsBean(StartupCracRegistration)
+        !ctx.containsBean(CracResourceRegistrar)
+        !ctx.containsBean(CracRedisConfiguration)
+        !ctx.containsBean(RedisCacheResource)
+        !ctx.containsBean(RedisClientResource)
+        !ctx.containsBean(StatefulRedisConnectionResource)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "CRaC Redis can be disabled"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run('redis.enabled': StringUtils.TRUE, 'crac.redis.enabled': StringUtils.FALSE)
+
+        expect:
+        ctx.containsBean(CracConfiguration)
+        ctx.containsBean(CracContextProvider)
+        ctx.containsBean(OrderedResource)
+        ctx.containsBean(StartupCracRegistration)
+        ctx.containsBean(CracResourceRegistrar)
+        !ctx.containsBean(CracRedisConfiguration)
+        !ctx.containsBean(RedisCacheResource)
+        !ctx.containsBean(RedisClientResource)
+        !ctx.containsBean(StatefulRedisConnectionResource)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void "CRaC Redis component can be disabled separately"() {
+        given:
+        String cfg = "crac.redis.$suffix-enabled"
+
+        ApplicationContext ctx = ApplicationContext.run(
+                'redis.enabled': StringUtils.TRUE,
+                "redis.caches.test.enabled": StringUtils.TRUE,
+                (cfg): StringUtils.FALSE,
+        )
+
+        expect:
+        ctx.containsBean(RedisCacheResource) == (suffix != 'cache')
+        ctx.containsBean(RedisClientResource) == (suffix != 'client')
+        ctx.containsBean(StatefulRedisConnectionResource) == (suffix != 'connection')
+
+        where:
+        suffix << ['cache', 'client', 'connection']
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/ExplicitCacheSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/ExplicitCacheSpec.groovy
@@ -1,0 +1,60 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.Logger
+import io.micronaut.configuration.lettuce.cache.RedisCache
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.StringUtils
+import io.micronaut.runtime.context.scope.Refreshable
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import jakarta.inject.Singleton
+import org.slf4j.LoggerFactory
+
+@Property(name = "spec.name", value = "ExplicitCacheSpec")
+@Property(name = "redis.caches.test.enabled", value = StringUtils.TRUE)
+class ExplicitCacheSpec extends BaseCacheSpecification {
+
+    @Inject
+    CacheService cacheService
+
+    def "redis cache can be checkpointed"() {
+        given:
+        Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
+        l.addAppender(appender)
+        appender.start()
+
+        when:
+        cacheService.put("foo", "bar")
+
+        and:
+        simulator.runBeforeCheckpoint()
+
+        then:
+        appender.events.formattedMessage.any { it.contains("Destroying Redis cache") }
+
+        when: "we trigger a restore"
+        simulator.runAfterRestore()
+
+        then: "the data is still there"
+        cacheService.get("foo", String) == "bar"
+    }
+
+    @Singleton
+    @Refreshable
+    @Requires(property = "spec.name", value = "ExplicitCacheSpec")
+    static class CacheService {
+
+        @Inject
+        @Named("test")
+        RedisCache redisCache
+
+        void put(Object s1, Object s2) {
+            redisCache.put(s1, s2)
+        }
+
+        <T> T get(Object s1, Class<T> aClass) {
+            redisCache.get(s1, aClass).get()
+        }
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/MemoryAppender.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/MemoryAppender.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+class MemoryAppender extends AppenderBase<ILoggingEvent> {
+
+    final List<ILoggingEvent> events = []
+
+    @Override
+    protected void append(ILoggingEvent e) {
+        synchronized (events) {
+            events.add(e)
+        }
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulConnectionSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulConnectionSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.Logger
+import io.lettuce.core.api.StatefulRedisConnection
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+
+@Property(name = "spec.name", value = "RedisCracSpec")
+@Property(name = "redis.cache.enabled", value = StringUtils.TRUE)
+class RedisStatefulConnectionSpec extends BaseCacheSpecification {
+
+    @Inject
+    StatefulRedisConnection<String, String> connection;
+
+    void "test redis connection"() {
+        given:
+        Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
+        l.addAppender(appender)
+        appender.start()
+
+        when:
+        connection.sync().set("foo", "bar")
+
+        then:
+        connection.sync().get("foo") == "bar"
+
+        when:
+        simulator.runBeforeCheckpoint()
+
+        then:
+        appender.events.formattedMessage.any { it.contains("Destroying Redis stateful connection") }
+
+        when: "we trigger a restore"
+        simulator.runAfterRestore()
+
+        and: "we get a new connection"
+        def newConnection = ctx.getBean(StatefulRedisConnection.class)
+
+        then: "the data is still there"
+        newConnection.sync().get("foo") == "bar"
+    }
+}

--- a/test-suite-redis/src/test/resources/logback.xml
+++ b/test-suite-redis/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.crac" level="debug"/>
+</configuration>


### PR DESCRIPTION
This adds support for Redis when using RedisCache, RedisClient or StatefuleRedisConnection.

It does not add support for `@Cacheable` with a redis backing store, that will be done at a later point.

Targetted for 1.2.1, but not sure if it should be a 1.3?