### PR TITLE
bug: StatefulRedisPubSubConnection beans are not supported

### DIFF
--- a/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
@@ -15,11 +15,13 @@
  */
 package io.micronaut.crac.resources.redis;
 
+import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.crac.OrderedResource;
 import org.crac.Context;
 import org.crac.Resource;
+import org.slf4j.Logger;
 
 /**
  * Redis resources are removed from the context, so they are automatically recreated on restore.
@@ -29,7 +31,22 @@ import org.crac.Resource;
  */
 @Internal
 @Experimental
-public abstract class AbstractRedisResource implements OrderedResource {
+public abstract class AbstractRedisResource<T> implements OrderedResource {
+
+    final BeanContext beanContext;
+
+    protected AbstractRedisResource(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    long action(T resource, Logger logger, String log) {
+        if (logger.isDebugEnabled()) {
+            logger.debug(log, resource);
+        }
+        long beforeStart = System.nanoTime();
+        beanContext.destroyBean(resource);
+        return System.nanoTime() - beforeStart;
+    }
 
     @Override
     public void afterRestore(Context<? extends Resource> context) throws Exception {

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 @Experimental
 public abstract class AbstractRedisResource<T> implements OrderedResource {
 
-    final BeanContext beanContext;
+    protected final BeanContext beanContext;
 
     protected AbstractRedisResource(BeanContext beanContext) {
         this.beanContext = beanContext;

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
@@ -44,12 +44,12 @@ public abstract class AbstractRedisResource<T> implements OrderedResource {
      * Destroy the bean.
      * @param resource the bean to destroy
      * @param logger the logger to use
-     * @param log the log message
+     * @param message the log message
      * @return the time taken to destroy the bean
      */
-    protected long action(T resource, Logger logger, String log) {
+    protected long destroyAction(T resource, Logger logger, String message) {
         if (logger.isDebugEnabled()) {
-            logger.debug(log, resource);
+            logger.debug(message, resource);
         }
         long beforeStart = System.nanoTime();
         beanContext.destroyBean(resource);

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/AbstractRedisResource.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 /**
  * Redis resources are removed from the context, so they are automatically recreated on restore.
  *
+ * @param <T> The type of resource
  * @author Tim Yates
  * @since 1.2.1
  */
@@ -39,7 +40,14 @@ public abstract class AbstractRedisResource<T> implements OrderedResource {
         this.beanContext = beanContext;
     }
 
-    long action(T resource, Logger logger, String log) {
+    /**
+     * Destroy the bean.
+     * @param resource the bean to destroy
+     * @param logger the logger to use
+     * @param log the log message
+     * @return the time taken to destroy the bean
+     */
+    protected long action(T resource, Logger logger, String log) {
         if (logger.isDebugEnabled()) {
             logger.debug(log, resource);
         }

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
@@ -39,13 +39,12 @@ import org.slf4j.LoggerFactory;
 @Requires(classes = {RedisCache.class})
 @Requires(bean = CracResourceRegistrar.class)
 @Requires(property = RedisCacheResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
-public class RedisCacheResource extends AbstractRedisResource {
+public class RedisCacheResource extends AbstractRedisResource<RedisCache> {
 
     static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".cache-enabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisCacheResource.class);
 
-    private final BeanContext beanContext;
     private final CracEventPublisher eventPublisher;
     private final RedisCache redisCache;
 
@@ -54,20 +53,13 @@ public class RedisCacheResource extends AbstractRedisResource {
         CracEventPublisher eventPublisher,
         RedisCache redisCache
     ) {
-        this.beanContext = beanContext;
+        super(beanContext);
         this.eventPublisher = eventPublisher;
         this.redisCache = redisCache;
     }
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Destroying Redis cache {}", redisCache);
-            }
-            long beforeStart = System.nanoTime();
-            beanContext.destroyBean(redisCache);
-            return System.nanoTime() - beforeStart;
-        });
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(redisCache, LOG, "Destroying Redis cache {}"));
     }
 }

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisCacheResource.java
@@ -60,6 +60,8 @@ public class RedisCacheResource extends AbstractRedisResource<RedisCache> {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(redisCache, LOG, "Destroying Redis cache {}"));
+        eventPublisher.fireBeforeCheckpointEvents(this, () ->
+            destroyAction(redisCache, LOG, "Destroying Redis cache {}")
+        );
     }
 }

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
@@ -40,13 +40,12 @@ import org.slf4j.LoggerFactory;
 @Requires(classes = {RedisClient.class})
 @Requires(bean = CracResourceRegistrar.class)
 @Requires(property = RedisClientResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
-public class RedisClientResource extends AbstractRedisResource {
+public class RedisClientResource extends AbstractRedisResource<RedisClient> {
 
     static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".client-enabled";
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisClientResource.class);
 
-    private final BeanContext beanContext;
     private final CracEventPublisher eventPublisher;
     private final RedisClient client;
 
@@ -55,21 +54,14 @@ public class RedisClientResource extends AbstractRedisResource {
         CracEventPublisher eventPublisher,
         RedisClient client
     ) {
-        this.beanContext = beanContext;
+        super(beanContext);
         this.eventPublisher = eventPublisher;
         this.client = client;
     }
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Destroying Redis client {}", client);
-            }
-            long beforeStart = System.nanoTime();
-            beanContext.destroyBean(client);
-            return System.nanoTime() - beforeStart;
-        });
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(client, LOG, "Destroying Redis client {}"));
     }
 
     @Override

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/RedisClientResource.java
@@ -61,7 +61,9 @@ public class RedisClientResource extends AbstractRedisResource<RedisClient> {
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(client, LOG, "Destroying Redis client {}"));
+        eventPublisher.fireBeforeCheckpointEvents(this, () ->
+            destroyAction(client, LOG, "Destroying Redis client {}")
+        );
     }
 
     @Override

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisConnectionResource.java
@@ -61,7 +61,9 @@ public class StatefulRedisConnectionResource extends AbstractRedisResource<State
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(connection, LOG, "Destroying Redis stateful connection {}"));
+        eventPublisher.fireBeforeCheckpointEvents(this, () ->
+            destroyAction(connection, LOG, "Destroying Redis stateful connection {}")
+        );
     }
 
     @Override

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
@@ -34,10 +34,10 @@ import org.slf4j.LoggerFactory;
  * Destroys any StatefulRedisPubSubConnection beans before checkpointing.
  *
  * @author Tim Yates
- * @since 1.2.1
+ * @since 1.2.2
  */
 @Experimental
-@EachBean(StatefulRedisPubSubConnection.class)
+@EachBean(StatefulRedisConnection.class)
 @Requires(classes = {StatefulRedisPubSubConnection.class})
 @Requires(bean = CracResourceRegistrar.class)
 @Requires(property = StatefulRedisPubSubConnectionResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
@@ -49,7 +49,7 @@ public class StatefulRedisPubSubConnectionResource extends AbstractRedisResource
 
     private final BeanContext beanContext;
     private final CracEventPublisher eventPublisher;
-    private final StatefulRedisPubSubConnection<?, ?> connection;
+    private final StatefulRedisConnection<?, ?> connection;
 
     public StatefulRedisPubSubConnectionResource(
         BeanContext beanContext,

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.crac.resources.redis;
+
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.crac.CracEventPublisher;
+import io.micronaut.crac.CracResourceRegistrar;
+import io.micronaut.crac.resources.NettyEmbeddedServerResource;
+import org.crac.Context;
+import org.crac.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Destroys any StatefulRedisPubSubConnection beans before checkpointing.
+ *
+ * @author Tim Yates
+ * @since 1.2.1
+ */
+@Experimental
+@EachBean(StatefulRedisPubSubConnection.class)
+@Requires(classes = {StatefulRedisPubSubConnection.class})
+@Requires(bean = CracResourceRegistrar.class)
+@Requires(property = StatefulRedisPubSubConnectionResource.ENABLED_PROPERTY, defaultValue = StringUtils.TRUE, value = StringUtils.TRUE)
+public class StatefulRedisPubSubConnectionResource extends AbstractRedisResource {
+
+    static final String ENABLED_PROPERTY = CracRedisConfigurationProperties.PREFIX + ".pubsub-connection-enabled";
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatefulRedisPubSubConnectionResource.class);
+
+    private final BeanContext beanContext;
+    private final CracEventPublisher eventPublisher;
+    private final StatefulRedisPubSubConnection<?, ?> connection;
+
+    public StatefulRedisPubSubConnectionResource(
+        BeanContext beanContext,
+        CracEventPublisher eventPublisher,
+        StatefulRedisPubSubConnection<?, ?> connection
+    ) {
+        this.beanContext = beanContext;
+        this.eventPublisher = eventPublisher;
+        this.connection = connection;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        eventPublisher.fireBeforeCheckpointEvents(this, () -> {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Destroying Redis stateful pubsub connection {}", connection);
+            }
+            long beforeStart = System.nanoTime();
+            beanContext.destroyBean(connection);
+            return System.nanoTime() - beforeStart;
+        });
+    }
+
+    @Override
+    public int getOrder() {
+        return NettyEmbeddedServerResource.ORDER - 1;
+    }
+}

--- a/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
+++ b/crac/src/main/java/io/micronaut/crac/resources/redis/StatefulRedisPubSubConnectionResource.java
@@ -62,7 +62,9 @@ public class StatefulRedisPubSubConnectionResource extends AbstractRedisResource
 
     @Override
     public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
-        eventPublisher.fireBeforeCheckpointEvents(this, () -> action(connection, LOG, "Destroying Redis stateful pubsub connection {}"));
+        eventPublisher.fireBeforeCheckpointEvents(this, () ->
+            destroyAction(connection, LOG, "Destroying Redis stateful pubsub connection {}")
+        );
     }
 
     @Override

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/BothRedisConnectionSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/BothRedisConnectionSpec.groovy
@@ -2,19 +2,23 @@ package io.micronaut.crac
 
 import ch.qos.logback.classic.Logger
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.util.StringUtils
 import jakarta.inject.Inject
 import org.slf4j.LoggerFactory
 
-@Property(name = "spec.name", value = "RedisStatefulConnectionSpec")
+@Property(name = "spec.name", value = "BothRedisConnectionSpec")
 @Property(name = "redis.cache.enabled", value = StringUtils.TRUE)
-class RedisStatefulConnectionSpec extends BaseCacheSpecification {
+class BothRedisConnectionSpec extends BaseCacheSpecification {
+
+    @Inject
+    StatefulRedisPubSubConnection<String, String> pubsub;
 
     @Inject
     StatefulRedisConnection<String, String> connection;
 
-    void "test redis connection"() {
+    void "test both redis connections being present"() {
         given:
         Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
         l.addAppender(appender)
@@ -27,18 +31,27 @@ class RedisStatefulConnectionSpec extends BaseCacheSpecification {
         connection.sync().get("foo") == "bar"
 
         when:
+        pubsub.sync().set("pub", "sub")
+
+        then:
+        pubsub.sync().get("pub") == "sub"
+
+        when:
         simulator.runBeforeCheckpoint()
 
         then:
         appender.events.formattedMessage.any { it.contains("Destroying Redis stateful connection") }
+        appender.events.formattedMessage.any { it.contains("Destroying Redis stateful pubsub connection") }
 
         when: "we trigger a restore"
         simulator.runAfterRestore()
 
-        and: "we get a new connection"
+        and: "we get new connections"
         def newConnection = ctx.getBean(StatefulRedisConnection.class)
+        def newPubSub = ctx.getBean(StatefulRedisPubSubConnection.class)
 
         then: "the data is still there"
         newConnection.sync().get("foo") == "bar"
+        newPubSub.sync().get("pub") == "sub"
     }
 }

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulPubSubConnectionSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulPubSubConnectionSpec.groovy
@@ -1,0 +1,45 @@
+package io.micronaut.crac
+
+import ch.qos.logback.classic.Logger
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
+import jakarta.inject.Inject
+import org.slf4j.LoggerFactory
+
+@Property(name = "spec.name", value = "RedisCracSpec")
+@Property(name = "redis.cache.enabled", value = StringUtils.TRUE)
+class RedisStatefulPubSubConnectionSpec extends BaseCacheSpecification {
+
+    @Inject
+    StatefulRedisPubSubConnection<String, String> connection;
+
+    void "test redis connection"() {
+        given:
+        Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
+        l.addAppender(appender)
+        appender.start()
+
+        when:
+        connection.sync().set("foo", "bar")
+
+        then:
+        connection.sync().get("foo") == "bar"
+
+        when:
+        simulator.runBeforeCheckpoint()
+
+        then:
+        appender.events.formattedMessage.any { it.contains("Destroying Redis stateful connection") }
+
+        when: "we trigger a restore"
+        simulator.runAfterRestore()
+
+        and: "we get a new connection"
+        def newConnection = ctx.getBean(StatefulRedisPubSubConnection.class)
+
+        then: "the data is still there"
+        newConnection.sync().get("foo") == "bar"
+    }
+}

--- a/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulPubSubConnectionSpec.groovy
+++ b/test-suite-redis/src/test/groovy/io/micronaut/crac/RedisStatefulPubSubConnectionSpec.groovy
@@ -3,19 +3,20 @@ package io.micronaut.crac
 import ch.qos.logback.classic.Logger
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
+import io.micronaut.context.BeanContext
 import io.micronaut.context.annotation.Property
 import io.micronaut.core.util.StringUtils
 import jakarta.inject.Inject
 import org.slf4j.LoggerFactory
 
-@Property(name = "spec.name", value = "RedisCracSpec")
+@Property(name = "spec.name", value = "RedisStatefulPubSubConnectionSpec")
 @Property(name = "redis.cache.enabled", value = StringUtils.TRUE)
 class RedisStatefulPubSubConnectionSpec extends BaseCacheSpecification {
 
     @Inject
     StatefulRedisPubSubConnection<String, String> connection;
 
-    void "test redis connection"() {
+    void "test redis pubsub connection"() {
         given:
         Logger l = (Logger) LoggerFactory.getLogger("io.micronaut.crac.resources")
         l.addAppender(appender)
@@ -31,7 +32,7 @@ class RedisStatefulPubSubConnectionSpec extends BaseCacheSpecification {
         simulator.runBeforeCheckpoint()
 
         then:
-        appender.events.formattedMessage.any { it.contains("Destroying Redis stateful connection") }
+        appender.events.formattedMessage.any { it.contains("Destroying Redis stateful pubsub connection") }
 
         when: "we trigger a restore"
         simulator.runAfterRestore()


### PR DESCRIPTION
As raised here https://github.com/micronaut-projects/micronaut-crac/issues/63#issuecomment-1494710527

StatefulRedisPubSubConnection beans were not destroyed during checkpointing, and so we were getting connection closed errors.