### PR TITLE
Update to use CRaC 1.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ micronaut-test = "4.0.1"
 groovy = "4.0.13"
 spock = "2.3-groovy-4.0"
 
-managed-crac = "1.3.0"
+managed-crac = "1.4.0"
 
 micronaut-logging = "1.0.0"
 


### PR DESCRIPTION
This exposes a MXBean for getting JVM level timing

See https://github.com/CRaC/org.crac/releases/tag/1.4.0