### PR TITLE
Ignore test when running on TestContainers Cloud

### DIFF
--- a/test-suite-docker/src/test/groovy/io/micronaut/crac/test/BaseSpec.groovy
+++ b/test-suite-docker/src/test/groovy/io/micronaut/crac/test/BaseSpec.groovy
@@ -2,6 +2,9 @@ package io.micronaut.crac.test
 
 import io.micronaut.http.client.BlockingHttpClient
 import io.micronaut.http.client.HttpClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.ContainerFetchException
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
@@ -11,20 +14,35 @@ import spock.lang.Specification
 
 abstract class BaseSpec extends Specification {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BaseSpec.class);
+
     @Shared
     @AutoCleanup
-    GenericContainer application = new GenericContainer(DockerImageName.parse("test-suite-docker:latest"))
-            .withPrivilegedMode(true)
-            .withExposedPorts(8080)
-            .withLogConsumer { print "DOCKER: $it.utf8String" }
-            .waitingFor(Wait.forHttp("/"))
+    GenericContainer application
 
     @Shared
     @AutoCleanup
     BlockingHttpClient client
 
     def setupSpec() {
-        application.start()
-        client = HttpClient.create(URI.create("http://${application.getHost()}:${application.getMappedPort(8080)}").toURL()).toBlocking()
+        application = new GenericContainer(DockerImageName.parse("test-suite-docker:latest"))
+                .withPrivilegedMode(true)
+                .withExposedPorts(8080)
+                .withLogConsumer { print "DOCKER: $it.utf8String" }
+                .waitingFor(Wait.forHttp("/"))
+        try {
+            application.start()
+            client = HttpClient.create(URI.create("http://${application.getHost()}:${application.getMappedPort(8080)}").toURL()).toBlocking()
+        } catch (ContainerFetchException e) {
+            LOG.error("""Failed to fetch the image for the test.
+                        |
+                        |This image should have been built by previous tasks in the build, so this is
+                        |probably caused by the use of TestContainers Cloud.
+                        |${'*' * 80}
+                        |Please switch TestContainers desktop to run containers locally, and try again.
+                        |${'*' * 80}""".stripMargin(),
+                    e
+            )
+        }
     }
 }

--- a/test-suite-docker/src/test/groovy/io/micronaut/crac/test/InfoSpec.groovy
+++ b/test-suite-docker/src/test/groovy/io/micronaut/crac/test/InfoSpec.groovy
@@ -1,7 +1,10 @@
 package io.micronaut.crac.test
 
+import spock.lang.Requires
+
 class InfoSpec extends BaseSpec {
 
+    @Requires({ instance.application.running })
     def "info is exposed as expected"() {
         when:
         Map result = client.retrieve("/info", Map)


### PR DESCRIPTION
When running with TestContainers Desktop, and running TestContainers in the cloud the InfoSpec fails as we build the image locally (using Gradle), and then try to load it in the Cloud (where it doesn't exist).

To prevent tests failing locally when this is enabled, this change:

1. Catches the error we see when running containers in the cloud
2. Logs the reason the test is ignored with a solution
3. Sets the test as Ignored (based on the container not running)